### PR TITLE
Remove TRANSITION mode

### DIFF
--- a/stochy_patterngenerator.F90
+++ b/stochy_patterngenerator.F90
@@ -250,10 +250,6 @@ module stochy_patterngenerator_mod
 
  subroutine patterngenerator_advance(rpattern,k,skeb_first_call)
 
-#ifdef TRANSITION
-!DIR$ OPTIMIZE:1
-#endif
-
     ! advance 1st-order autoregressive process with
     ! specified autocorrelation (phi) and variance spectrum (spectrum)
     real(kind_dbl_prec) :: noise_e(len_trie_ls,2)


### PR DESCRIPTION
Changes:

- remove all code related to the deprecated TRANSITION mode for Theia+Intel15, affects stochy_patterngenerator.F90 only

For regression testing, see NCAR/NEMSfv3gfs#251