### PR TITLE
Fix non-existent include directory warning with GNU compiler

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ endif
 
 LIBRARY  = libstochastic_physics.a
 
-FFLAGS   += -I./include -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I$(FMS_DIR) -I../FV3/namphysics
+FFLAGS   += -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I$(FMS_DIR) -I../FV3/namphysics
 
 SRCS_F   =
 


### PR DESCRIPTION
Remove ./include from list of include directories in top-level makefile to fix non-existent include directory warning with GNU compiler.

This PR is tested together with a set of PRs targeted at the dtc/develop branches in the NCAR GitHub, see https://github.com/NCAR/ufs-weather-model/pull/3.

Merging this PR into the master branch requires the ok from/coordination with @junwang-noaa and @DusanJovic-NOAA, too. I think it is safe to merge, because this directory ./include inside stochastic_physics is never created.
