### PR TITLE
ufs_public_release: update from DTC (fix compiler warnings)

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ endif
 
 LIBRARY  = libstochastic_physics.a
 
-FFLAGS   += -I./include -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I$(FMS_DIR) -I../FV3/namphysics
+FFLAGS   += -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I$(FMS_DIR) -I../FV3/namphysics
 
 SRCS_F   =
 


### PR DESCRIPTION
This PR fixes compiler warnings about non-existent include directories.
