### PR TITLE
Remove non-existing include directory namphysics from makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ endif
 
 LIBRARY  = libstochastic_physics.a
 
-FFLAGS   += -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I$(FMS_DIR) -I../FV3/namphysics
+FFLAGS   += -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I$(FMS_DIR)
 
 SRCS_F   =
 


### PR DESCRIPTION
namphysics was removed from fv3atm a few PRs ago. The stochastic_physics makefile still has an include flag for it, which causes lots of warnings like
```
f951: Warning: Nonexistent include directory '../FV3/namphysics' [-Wmissing-include-dirs]
```
with the GNU compiler. This PR removes the include flag.

@dusanjovic-noaa @junwang-noaa