### PR TITLE
CMakeLists.txt changes for FMS 2021.03

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ list(APPEND _stoch_phys_srcs
 add_library(stochastic_physics ${_stoch_phys_srcs})
 add_dependencies(stochastic_physics fms)
 
-target_compile_definitions(stochastic_physics PRIVATE INTERNAL_FILE_NML)
+if(32BIT)
+  target_compile_definitions(stochastic_physics PRIVATE INTERNAL_FILE_NML OVERLOAD_R4)
+else()
+  target_compile_definitions(stochastic_physics PRIVATE INTERNAL_FILE_NML)  
+endif()
 
 set_target_properties(stochastic_physics PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
 target_include_directories(stochastic_physics INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>


### PR DESCRIPTION
This PR adds the compile-time flag `OVERLOAD_R4` for a `32BIT` build to the `CMakeLists.txt` file.  This change is required for compatibility with FMS 2021.03 where the scope of the FMS compile-time macros has been changed from PUBLIC to PRIVATE.  With this change, stochastic_physics will not inherit FMS compile-time flags and will need to be defined explicitly.  