### PR TITLE
CA restart fix

### DIFF
--- a/update_ca.F90
+++ b/update_ca.F90
@@ -166,7 +166,7 @@ id_restart = register_restart_field (CA_restart, fn_phy, "board", &
 id_restart = register_restart_field (CA_restart, fn_phy, "lives", &
      lives(:,:,1), domain = domain_ncellx,  mandatory=.false.)
 
-fname = 'INPUT/'//trim(fn_phy)
+fname = 'INPUT/ca_data.tile1.nc'
 if (file_exist(fname)) then
    !--- read the CA restart data
    call mpp_error(NOTE,'reading CA restart data from INPUT/ca_data.tile*.nc')


### PR DESCRIPTION
This PR contains one line change to fix CA restart reproducibility issue in the coupled P7 regression test. This will enable the coupled restart tests in the ufs-weather-model [PR#765](https://github.com/ufs-community/ufs-weather-model/pull/765)

Related PRs: 
- ufs-weather-model [PR#819](https://github.com/ufs-community/ufs-weather-model/pull/819)
- fv3atm [PR#391](https://github.com/NOAA-EMC/fv3atm/pull/391)
- CCPP physics [PR#732](https://github.com/NCAR/ccpp-physics/pull/732)
- Stochastic physics [PR#46](https://github.com/noaa-psd/stochastic_physics/pull/46) 