### PR TITLE
Change ifdef statement for quad precision in kinddef.F90

### DIFF
--- a/kinddef.F90
+++ b/kinddef.F90
@@ -16,7 +16,7 @@ module kinddef
       integer, parameter :: kind_dbl_prec = 8
       integer, parameter :: kind_io8      = 8
 
-#ifdef __PGI
+#ifdef NO_QUAD_PRECISION
       integer, parameter :: kind_qdt_prec = 8
 #else
       integer, parameter :: kind_qdt_prec = 16

--- a/spectral_transforms.F90
+++ b/spectral_transforms.F90
@@ -1972,7 +1972,12 @@ module spectral_transforms
                                              cons2 = 2.d0, cons4 = 4.d0, &
                                              cons180 = 180.d0, &
                                              cons0p25 = 0.25d0
+#ifdef NO_QUAD_PRECISION
+      real(kind=kind_qdt_prec), parameter :: eps = 1.d-12
+#else
       real(kind=kind_qdt_prec), parameter :: eps = 1.d-20
+#endif
+
 !
 ! for better accuracy to select smaller number
 !     eps = 1.d-12


### PR DESCRIPTION
Fixes https://github.com/noaa-psd/stochastic_physics/issues/52 by replacing `#ifdef _PGI` with `#ifdef NO_QUAD_PRECISION`.

This is the same CPP directive that is used for the FV3 dycore (GFDL_atmos_cubed_sphere). Since it doesn't change the default (which is to use quad precision), it should be safe to merge unless there is an application using PGI. This application would need to pass `-DNO_QUAD_PRECISION` to work.

**NEEDS TO BE TESTED!**