### PR TITLE
Feature/lndp noahmp2 : add land perturbation scheme for Noah-MP fractional veg 

### DIFF
--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -3,7 +3,8 @@ References
 
 Berner, J., G. Shutts, M. Leutbecher, and T. Palmer, 2009: A spectral stochastic kinetic energy backscatter scheme and its impact on flow- dependent predictability in the ECMWF ensemble prediction system. J. Atmos. Sci., 66, 603–626, `doi:10.1175/2008JAS2677.1 <https://journals.ametsoc.org/doi/full/10.1175/2008JAS2677.1>`_
 
-Gehne, M., T. Hamill, G. Bates, P. Pegion, W. Kolczynski 2019: Land-surface parameter and state perturbations in the Global Ensemble Forecast System. Mon. Wea. Rev. 147, 1319–1340 `doi:10.1175/MWR-D-18-0057.1 <https://journals.ametsoc.org/doi/10.1175/MWR-D-18-0057.1>`_
+Draper, C, 2021: Accounting for Land Model Uncertainty in Numerical Weather Prediction Ensemble Systems: Toward Ensemble-Based Coupled Land–Atmosphere Data Assimilation, J Hydromet, 22(8), 2089-2104, `<https://journals.ametsoc.org/view/journals/hydr/22/8/JHM-D-21-0016.1.xml>`_
+
 
 Palmer, T. N., R. Buizza, F. Doblas-Reyes, T. Jung, M. Leutbecher, G. J. Shutts,M. Steinheimer, and A.Weisheimer, 2009: Stochastic parametrization and model uncertainty. ECMWF Tech. Memo. 598, 42 pp `doi:10.21957/ps8gbwbdv <https://www.ecmwf.int/node/11577>`_
 

--- a/docs/source/users_guide.rst
+++ b/docs/source/users_guide.rst
@@ -2,7 +2,7 @@ Users Guide
 ==================================================
 The stochastic physics currently only works with the UFS-atmosphere model
 
-Currently, 3 stochastic schemes are used operationally at NCEP/EMC: Stochastic Kinetic Energy Backscatter (SKEB; Berner et al., 2009), Stochastically Perturbed Physics Tendencies (SPPT; Palmer et al., 2009), and Specific Humidity perturbations (SHUM), which is inspired by Tompkins and Berner, 2008. In addition there is the ability to perturb certain land model/surface parameters (Gehne et al, 2019), and a cellular automata scheme (Bengtsson et al. 2019) which interacts directly with the convective parameterization.
+Currently, 3 stochastic schemes are used operationally at NCEP/EMC: Stochastic Kinetic Energy Backscatter (SKEB; Berner et al., 2009), Stochastically Perturbed Physics Tendencies (SPPT; Palmer et al., 2009), and Specific Humidity perturbations (SHUM), which is inspired by Tompkins and Berner, 2008. In addition there is the ability to perturb certain land model/surface parameters (Draper, 2021), and a cellular automata scheme (Bengtsson et al. 2019) which interacts directly with the convective parameterization.
 
 SKEB adds wind perturbations to model state.  Perturbations are random in space/time, but amplitude is determined by a smoothed dissipation estimate provided by the dynamical core. 
 Addresses errors in the dynamics  - more active in the mid-latitudes
@@ -11,7 +11,7 @@ SPPT multiplies the physics tendencies by a random number O [0,2] before updatin
 
 SHUM multiply the low-level specific humidity by a small random number each time-step. It attempts to address missing physics (cold pools, gust fronts), most active in convective regions
 
-Land surface perturbations allow for land surface parameters such as Albedo, Soil Hydraulic Conductivity, LAI, and roughness lengths to vary in space. Addresses error in the land model and land-atmosphere interactions.  
+Land surface perturbations can be applied to the land model parameters and land model prognostic variables. The scheme is intended to address errors in the land model and land-atmosphere interactions.  
 
 Due to the model’s numerics, any stochastic perturbation needs to be correlated in space and time in order to have the desired effect of upscale growth of the perturbations. This is achieved by creating a random pattern that has a specified decorrelation length-scale and is a first order auto-regressive process AR(1) in time with a specified decorrelation time-scale.  (The CA random pattern generator also satisfies this condition)
 

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -45,14 +45,13 @@ module lndp_apply_perts_mod
 ! can perturb parameters every time step. Hence, need to specify the perturbations 
 ! as a rate. 
 !
-! The above cases are controlled by the lndp_model_type variable, 
-! combined with setting tfactor_state below.
+! The above cases are controlled by the lndp_model_type variable. 
 !
-! If adding new parameters, need to check how/whether 
-! the parameters are updated. 
+! If adding perturbations to new parameters, need to check how/whether 
+! the parameters are updated by the model.
 
-    subroutine lndp_apply_perts(blksz, lsm, lsm_noah, lsm_ruc, lsm_noahmp, lsoil,&
-                dtf, kdt, n_var_lndp, lndp_var_list, lndp_prt_list,              &
+    subroutine lndp_apply_perts(blksz, lsm, lsm_noah, lsm_ruc, lsm_noahmp, iopt_dveg, & 
+                lsoil, dtf, kdt, n_var_lndp, lndp_var_list, lndp_prt_list,            &
                 sfc_wts, xlon, xlat, stype, smcmax, smcmin, param_update_flag,  &
                 smc, slc, stc, vfrac, alvsf, alnsf, alvwf, alnwf, facsf, facwf, &
                 snoalb, semis, zorll, ierr)
@@ -61,7 +60,7 @@ module lndp_apply_perts_mod
 
         ! intent(in)
         integer,                      intent(in) :: blksz(:)
-        integer,                      intent(in) :: n_var_lndp, lsoil, kdt
+        integer,                      intent(in) :: n_var_lndp, lsoil, kdt, iopt_dveg
         integer,                      intent(in) :: lsm, lsm_noah, lsm_ruc, lsm_noahmp
         character(len=3),             intent(in) :: lndp_var_list(:)
         real(kind=kind_dbl_prec),     intent(in) :: lndp_prt_list(:)
@@ -128,9 +127,17 @@ module lndp_apply_perts_mod
                     print*, &
                      'ERROR:  lndp_prt_list option in lndp_apply_pert', trim(lndp_var_list(v)) , & 
                      ' has not been checked for Noah-MP. Please check how the parameter is set/updated ', & 
-                     ' before applying'
+                     ' before applying. Note: in Noah-MP many variables that have traditionally been', & 
+                     ' externally specified parameters are now prognostic. Also, many parameters are', & 
+                     ' set at each Noah-MP model call from data tables' 
                     ierr = 10
                     return
+                case ('veg') 
+                    if (iopt_dveg ~=4 ) then 
+                    print*, &
+                     'ERROR:  veg perturbations have not yet been coded for dveg options other than 4' 
+                      ierr = 10 
+                      return 
                 end select
             enddo 
         endif

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -167,8 +167,6 @@ module lndp_apply_perts_mod
                 do_pert_param=.true.
                 tfactor_param=1.
             endif
-        case(0) 
-                ! no perts requested, do nothing
         case default
             print*, &
              'ERROR: unrecognised lndp_model_type option in lndp_apply_pert, exiting', trim(lndp_var_list(v))
@@ -197,17 +195,16 @@ module lndp_apply_perts_mod
         do nb =1,nblks
            do i = 1, blksz(nb)
 
-             !if ( nint(Sfcprop(nb)%slmsk(i)) .NE. 1) cycle ! skip if not land
-
-             !if ( ((isot == 1) .and. (soiltyp == 16)) &
-             !  .or.( (isot == 0) .and. (soiltyp  == 9 )) ) cycle ! skip if land-ice
-
              if ( smc(nb,i,1) .EQ. 1.) cycle ! skip  non-soil (land-ice and non-land)
              ! set printing
              if ( (i==print_i)  .and. (nb==print_nb) ) then
                 print_flag = .true.
              else
                 print_flag=.false.
+             endif
+
+             if (print_flag) then 
+                write(6,*) 'LNDPtmp', vfrac(nb,i)
              endif
 
              do v = 1,n_var_lndp

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -133,11 +133,12 @@ module lndp_apply_perts_mod
                     ierr = 10
                     return
                 case ('veg') 
-                    if (iopt_dveg ~=4 ) then 
+                    if (iopt_dveg .NE. 4 ) then 
                     print*, &
                      'ERROR:  veg perturbations have not yet been coded for dveg options other than 4' 
                       ierr = 10 
                       return 
+                    endif
                 end select
             enddo 
         endif

--- a/main.doc
+++ b/main.doc
@@ -6,7 +6,7 @@
  *
  *The stochastic physics currently only works with the UFS-atmosphere model
  *
- *Currently, 3 stochastic schemes are used operationally at NCEP/EMC: Stochastic Kinetic Energy Backscatter (SKEB; Berner et al., 2009), Stochastically Perturbed Physics Tendencies (SPPT; Palmer et al., 2009), and Specific Humidity perturbations (SHUM), which is inspired by Tompkins and Berner, 2008. In addition there is the ability to perturb certain land model/surface parameters (Gehne et al, 2019), and a cellular automata scheme (Bengtsson et al. 20XX) which interacts directly with the convective parameterization.
+ *Currently, 3 stochastic schemes are used operationally at NCEP/EMC: Stochastic Kinetic Energy Backscatter (SKEB; Berner et al., 2009), Stochastically Perturbed Physics Tendencies (SPPT; Palmer et al., 2009), and Specific Humidity perturbations (SHUM), which is inspired by Tompkins and Berner, 2008. In addition there is the ability to perturb certain land model/surface parameters (Draper, 2021), and a cellular automata scheme (Bengtsson et al. 20XX) which interacts directly with the convective parameterization.
  *
  *SKEB adds wind perturbations to model state.  Perturbations are random in space/time, but amplitude is determined by a smoothed dissipation estimate provided by the dynamical core.
  *Addresses errors in the dynamics  - more active in the mid-latitudes

--- a/stochy_namelist_def.F90
+++ b/stochy_namelist_def.F90
@@ -10,7 +10,7 @@
       implicit none
 
       public
-      integer, parameter :: max_n_var_lndp = 6 ! must match value used in GFS_typedefs
+      integer, parameter :: max_n_var_lndp = 20 ! must match value used in GFS_typedefs
       integer, parameter :: max_n_var_spp  = 6 ! must match value used in GFS_typedefs
       integer nssppt,nsshum,nsepbl,nsocnsppt,nsskeb,lon_s,lat_s,ntrunc
 
@@ -37,6 +37,7 @@
       integer n_var_lndp
       integer(kind=kind_dbl_prec),dimension(5) ::iseed_lndp
       integer lndp_type
+      integer lndp_model_type
       character(len=3), dimension(max_n_var_lndp)         ::  lndp_var_list
       real(kind=kind_dbl_prec), dimension(max_n_var_lndp) ::  lndp_prt_list
 


### PR DESCRIPTION
Updates to allow land perturbation scheme to be applied for Noah-MP. Currently, for Noah-MP model parameters can perturb only vegetation fraction, to address issue #55. 

Three linked PRS: 
stochastic_physics ( Feature/lndp noahmp2 : add land perturbation scheme for Noah-MP fractional veg https://github.com/noaa-psd/stochastic_physics/pull/56)
ufs-weather-model (add land perturbation scheme for Noah-MP fractional veg [#1143](https://github.com/ufs-community/ufs-weather-model/pull/1143 )
fv3-atm ( Feature/lndp noahmp2 : add land perturbation scheme for Noah-MP fractional veg https://github.com/NOAA-EMC/fv3atm/pull/513)

Main code changes: 
-added lsm_noahmp model option to lndp_type==2 land perturbation scheme  (fv3-atm, stochastic_physics)
-updated comments
-cleaned up the namelists to make the different options clearer. Removed misleading lndp_each_step variable from gfs_physics_nml, and replaced it with "lndp_model_type" in the nam_sfcperts namelist for the different forecast types (cycling DA, short forecasts, perturbing only initial conditions)   (fv3-atm, stochastic_physics, ufs-weather-model)
NOTE: see note below, re: specification of smc perturbation for RAP/HRRR/etc (lndp_model_type==2)
-revised code in stochastic_physics_wrapper to only allocate arrays that will be used when passed into lndp_apply_perts (fv3-atm) 
-deleted unused albedo arrays in stochastic_physics_wrapper and lndp_apply_perts (fv3-atm, stochastic_physics) 
-fixed bug causing precision errors when calculating the soil moisture ice content (often ~0.0; stochastic_physics) 
-fixed bug in which lndp_apply_perts wasn't called for nscyc = 0. (fv3-atm) 
-increased max_nvar_lndp at Jeff Ator's request (fv3-atm) 
-added  a new test for the Noah-MP and lndp==2 combination (ufs-weather-model) 

Changes to tests: 
-added new control_p8_lndp to test Noah-MP land perts 
-updated previous lndp tests with new results, now that  precision errors when calculating the soil moisture ice content is fixed 
-also, for rap_lndp_debug the perturbation to smc at the initial conditions (applied only once) was previously specified as a rate, then divided by the time step before being applied. This makes the magnitude of perturbation dependent on the model time step. This has been fixed with the introduction of the lndp_model_type==2 option for regional sysyems, so that the perturbation is now specified as an absolute amount (changed 0.2 to 0.017 in the test). The previously used smc pert needs to be multiplied by timestep/3600 to get the same results with the new code.

New tests are here on hera: 
/scratch2/BMC/gsienkf/Clara.Draper/stmp4/Clara.Draper/FV3_RT/REGRESSION_TEST_INTEL

Note: long term, we will probably want to move the Noah-MP perturbations into the land model driver, as it's getting increasingly awkward in it's current location.