### PR TITLE
re-add external esmf_dgemm to spectral_transforms.F90 to address compiler warning

### DIFF
--- a/spectral_transforms.F90
+++ b/spectral_transforms.F90
@@ -42,6 +42,8 @@ module spectral_transforms
 
 #ifdef CESMCOUPLED
       external dgemm
+#else
+      external esmf_dgemm
 #endif
 !     
       integer, intent(in)     :: nvars


### PR DESCRIPTION
This re-adds an `external esmf_dgemm` that was replaced in https://github.com/NOAA-PSL/stochastic_physics/pull/81 with:
```
#ifdef CESMCOUPLED
      external dgemm
#endif
```
to address a compiler warning of
```
.../ufs-weather-model/stochastic_physics/spectral_transforms.F90(121): warning #8889: Explicit interface or EXTERNAL declaration is required.   [ESMF_DGEMM]
.../ufs-weather-model/stochastic_physics/spectral_transforms.F90(132): warning #8889: Explicit interface or EXTERNAL declaration is required.   [ESMF_DGEMM]
```
in UFS RT cpld_debug_gfsv17 for operational implementation