### PR TITLE
limit smc/stc random pattern generation to initial time

### DIFF
--- a/get_stochy_pattern.F90
+++ b/get_stochy_pattern.F90
@@ -30,14 +30,14 @@ module get_stochy_pattern_mod
 !>@brief The subroutine 'get_random_pattern_sfc' converts spherical harmonics to the gaussian grid then interpolates to the target grid
 !>@details This subroutine is for a 2-D (lat-lon) scalar field
 subroutine get_random_pattern_sfc(rpattern,npatterns,&
-           gis_stochy,pattern_3d)
+           gis_stochy,pattern_3d,lndp_loop)
 !\callgraph
 
 ! generate a random pattern for stochastic physics
  implicit none
  type(random_pattern), intent(inout) :: rpattern(npatterns)
  type(stochy_internal_state), intent(in) :: gis_stochy
- integer,intent(in)::   npatterns
+ integer,intent(in)::   npatterns, lndp_loop
 
  integer i,j,lat,n,k
  real(kind=kind_dbl_prec), dimension(lonf,gis_stochy%lats_node_a,1):: wrk2d
@@ -50,7 +50,7 @@ subroutine get_random_pattern_sfc(rpattern,npatterns,&
  real(kind=kind_dbl_prec),intent(out) :: pattern_3d(gis_stochy%nx,gis_stochy%ny,n_var_lndp)
  real(kind=kind_dbl_prec) :: pattern_1d(gis_stochy%nx)
 
- do k=1,n_var_lndp
+ do k=1,lndp_loop
    kmsk0 = 0
    glolal = 0.
    do n=1,npatterns

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -107,6 +107,9 @@ module lndp_apply_perts_mod
         real(kind=kind_phys), dimension(9), parameter :: smc_vertscale_ruc = (/1.0,0.9,0.8,0.6,0.4,0.2,0.1,0.05,0./)
         real(kind=kind_phys), dimension(9), parameter :: stc_vertscale_ruc = (/1.0,0.9,0.8,0.6,0.4,0.2,0.1,0.05,0./)
         real(kind=kind_phys), dimension(9), parameter :: zs_ruc = (/0.05, 0.15, 0.20, 0.20, 0.40, 0.60, 0.60, 0.80, 1.00/)
+        logical :: mask(size(lndp_var_list))
+        character(len=len(lndp_var_list)), allocatable :: new_list(:)
+        integer :: lndp_i, n_var_lndp_new
 
         ierr = 0
 
@@ -197,6 +200,20 @@ module lndp_apply_perts_mod
 
         call  set_printing_nb_i(blksz,xlon,xlat,print_i,print_nb)
 
+        ! skip smc/stc when kdt ne 2
+        if (kdt .ne. 2) then
+          new_list = lndp_var_list
+          n_var_lndp_new = 0
+          do lndp_i = 1, size(lndp_var_list)
+            mask(lndp_i) = (trim(lndp_var_list(lndp_i)) /= 'smc') .and. (trim(lndp_var_list(lndp_i)) /= 'stc')
+          end do
+          new_list = pack(lndp_var_list, mask)
+          n_var_lndp_new=size(new_list)
+        else
+          new_list = lndp_var_list
+          n_var_lndp_new = n_var_lndp
+        endif
+
         do nb =1,nblks
            do i = 1, blksz(nb)
 
@@ -208,8 +225,8 @@ module lndp_apply_perts_mod
                 print_flag=.false.
              endif
 
-             do v = 1,n_var_lndp
-                select case (trim(lndp_var_list(v)))
+             do v = 1,n_var_lndp_new
+                select case (trim(new_list(v)))
                 !=================================================================
                 ! State updates - performed every cycle
                 !=================================================================

--- a/stochastic_physics.F90
+++ b/stochastic_physics.F90
@@ -443,7 +443,7 @@ if ( lndp_type .EQ. 2  ) then
       mask(lndp_i) = (trim(lndp_var_list(lndp_i)) /= 'smc') .and. (trim(lndp_var_list(lndp_i)) /= 'stc')
     end do 
     new_list = pack(lndp_var_list, mask)
-    do lndp_i =1,size(lndp_var_list)
+    do lndp_i =1,size(new_list)
       if   (new_list(lndp_i) .EQ. 'XXX')   then
         cycle
       else

--- a/stochy_patterngenerator.F90
+++ b/stochy_patterngenerator.F90
@@ -250,6 +250,7 @@ module stochy_patterngenerator_mod
    noise = noise*sqrt(1./ntrunc)
    noise_e = 0.; noise_o = 0.
    ! subset
+   !$OMP PARALLEL DO PRIVATE(nm)
    do nn=1,len_trie_ls
       nm = rpattern%idx_e(nn)
       if (nm == 0) cycle
@@ -260,6 +261,9 @@ module stochy_patterngenerator_mod
         noise_e(nn,2) = 0.
       endif
    enddo
+   !$OMP END PARALLEL DO
+
+   !$OMP PARALLEL DO PRIVATE(nm)
    do nn=1,len_trio_ls
       nm = rpattern%idx_o(nn)
       if (nm == 0) cycle
@@ -270,6 +274,7 @@ module stochy_patterngenerator_mod
         noise_o(nn,2) = 0.
       endif
    enddo
+   !$OMP END PARALLEL DO
  end subroutine getnoise
 
 !>@brief The subroutine 'patterngenerator_advance' advance 1st-order autoregressive process
@@ -289,6 +294,8 @@ module stochy_patterngenerator_mod
     else
        k2=k
     endif
+
+    !$OMP PARALLEL DO PRIVATE(nm)
     do nn=1,len_trie_ls
        nm = rpattern%idx_e(nn)
        if (nm == 0) cycle
@@ -297,6 +304,9 @@ module stochy_patterngenerator_mod
        rpattern%spec_e(nn,2,k) =  rpattern%phi*rpattern%spec_e(nn,2,k2) + &
        rpattern%stdev*sqrt(1.-rpattern%phi**2)*rpattern%varspectrum(nm)*noise_e(nn,2)
     enddo
+    !$OMP END PARALLEL DO
+
+    !$OMP PARALLEL DO PRIVATE(nm)
     do nn=1,len_trio_ls
        nm = rpattern%idx_o(nn)
        if (nm == 0) cycle
@@ -305,6 +315,7 @@ module stochy_patterngenerator_mod
        rpattern%spec_o(nn,2,k) =  rpattern%phi*rpattern%spec_o(nn,2,k2) + &
        rpattern%stdev*sqrt(1.-rpattern%phi**2)*rpattern%varspectrum(nm)*noise_o(nn,2)
     enddo
+    !$OMP END PARALLEL DO
  end subroutine patterngenerator_advance
 
 !>@brief The subroutine 'setvarspect' calculates the variance spectrum


### PR DESCRIPTION
This PR:

1. limits smc/stc random pattern generation to initial time
2. adds omp directives to a couple of subroutines

Both changes aim to speed up RRFS ensemble forecast for operational implementation